### PR TITLE
deep_buffer & raw removal in audio_policy.conf for max compatibility

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -300,6 +300,27 @@ if [ -f "$VENDOR_CONFIG" ]; then
   sed -i 's/^effects {/effects {\n  v4a_standard_fx {\n    library v4a_fx\n    uuid 41d3c987-e6cf-11e3-a88a-11aba5d5c51b\n  }/g' $VENDOR_CONFIG
 fi
 
+# deep_buffer & raw removal in audio_policy.conf for max compatibility
+# Only use "setporp audio.deep_buffer.media false" in post-fs-data.sh
+# is not enough to get v4a process with SoundCloud
+if [ -f "/system/etc/audio_policy.conf" ]; then
+  cp -af /system/etc/audio_policy.conf $MODPATH/system/etc/audio_policy.conf
+  sed -i '/deep_buffer {/,/}/d' $MODPATH/system/etc/audio_policy.conf
+  sed -i '/raw {/,/}/d' $MODPATH/system/etc/audio_policy.conf
+fi
+
+if [ -f "/system/vendor/etc/audio_policy.conf" ]; then
+  cp -af /system/vendor/etc/audio_policy.conf $MODPATH/system/vendor/etc/audio_policy.conf
+  sed -i '/deep_buffer {/,/}/d' $MODPATH/system/vendor/etc/audio_policy.conf
+  sed -i '/raw {/,/}/d' $MODPATH/system/vendor/etc/audio_policy.conf
+fi
+
+if [ -f "/system/vendor/etc/audio_output_policy.conf" ]; then
+  cp -af /system/vendor/etc/audio_output_policy.conf $MODPATH/system/vendor/etc/audio_output_policy.conf
+  sed -i '/deep_buffer {/,/}/d' $MODPATH/system/vendor/etc/audio_output_policy.conf
+  sed -i '/raw {/,/}/d' $MODPATH/system/vendor/etc/audio_output_policy.conf
+fi
+
 # Handle replace folders
 for TARGET in $REPLACE; do
   mktouch $MODPATH$TARGET/.replace


### PR DESCRIPTION
deep_buffer & raw removal in audio_policy.conf for max compatibility. 
Reference here, http://forum.xda-developers.com/android/software/r-s-e-sound-systems-auditory-research-t3379709
"deep_buffer and raw removal from audio_policy.conf for maximum processing of all media players and System UI audio."

Though using "setporp audio.deep_buffer.media false" in post-fs-data.sh works under some condition, v4a still fails to process with SoundCloud unless deep_buffer is deleted.
